### PR TITLE
Add the option to do insecure http

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,3 +2,4 @@ PUBLIC_BACKEND_ENDPOINT = "the url and port at which your backend is running, th
 ZENO_USER_POOL_AUTH_REGION = "cognito user pool auth region"
 ZENO_USER_POOL_CLIENT_ID = "cognito user pool client id"
 ZENO_USER_POOL_ID = "cognito user pool id"
+ALLOW_INSECURE_HTTP = "true or false, whether to allow http or not"

--- a/frontend/src/routes/(app)/+layout.server.ts
+++ b/frontend/src/routes/(app)/+layout.server.ts
@@ -1,5 +1,6 @@
 import { dev } from '$app/environment';
-import { env } from '$env/dynamic/public';
+import { env as public_env } from '$env/dynamic/public';
+import { env as private_env } from '$env/dynamic/private';
 import { extractUserFromSession, refreshAccessToken } from '$lib/auth/cognito.js';
 import type { AuthUser } from '$lib/auth/types.js';
 import { OpenAPI, ZenoService } from '$lib/zenoapi';
@@ -22,7 +23,7 @@ export const load = async ({ cookies, url }) => {
 				path: '/',
 				httpOnly: true,
 				sameSite: 'strict',
-				secure: !dev,
+				secure: !dev && private_env.ALLOW_INSECURE_HTTP != 'true',
 				maxAge: 60 * 60 * 24 * 30
 			});
 		} catch (error) {
@@ -35,7 +36,7 @@ export const load = async ({ cookies, url }) => {
 		throw redirect(303, `/login?redirectTo=${url.pathname}`);
 	}
 
-	OpenAPI.BASE = env.PUBLIC_BACKEND_ENDPOINT + '/api';
+	OpenAPI.BASE = public_env.PUBLIC_BACKEND_ENDPOINT + '/api';
 	OpenAPI.HEADERS = {
 		Authorization: 'Bearer ' + cognitoUser.accessToken
 	};

--- a/frontend/src/routes/(user)/login/+page.server.ts
+++ b/frontend/src/routes/(user)/login/+page.server.ts
@@ -1,4 +1,5 @@
 import { dev } from '$app/environment';
+import { env as private_env } from '$env/dynamic/private';
 import { extractUserFromSession, getSession } from '$lib/auth/cognito';
 import { OpenAPI } from '$lib/zenoapi';
 import { fail, redirect } from '@sveltejs/kit';
@@ -40,7 +41,7 @@ export const actions: Actions = {
 				path: '/',
 				httpOnly: true,
 				sameSite: 'strict',
-				secure: !dev,
+				secure: !dev && private_env.ALLOW_INSECURE_HTTP != 'true',
 				maxAge: 60 * 60 * 24 * 30
 			});
 		} catch (error) {


### PR DESCRIPTION
This PR (temporarily) adds the option to run on insecure http servers.

This should be fixed in a future PR (noted https://linear.app/zenoml/issue/ZEN-38/infra-add-encryption).