### PR TITLE
feat: change binary metadata color if no metric

### DIFF
--- a/frontend/src/lib/components/metadata/cells/metadata-cells/BinaryMetadataCell.svelte
+++ b/frontend/src/lib/components/metadata/cells/metadata-cells/BinaryMetadataCell.svelte
@@ -41,11 +41,11 @@
 	<div class="flex px-1 w-full">
 		<div style:width="{widthScale(histogram[0].filteredCount ?? 0)}%">
 			<div
-				class="flex px-1 py-2.5 cursor-pointer flex-col items-center box-border border-2 border-transparent font-bold rounded-l-xl {selectedValue !==
+				class="flex px-1 py-2.5 cursor-pointer flex-col items-center box-border border-2 border-transparent font-bold rounded-l-xl text-background {selectedValue !==
 					null && selectedValue === true
 					? 'border-primary'
 					: ''}"
-				style="color: white; background-color: {$metricRangeColorScale(histogram[0].metric ?? 0)}"
+				style="background-color: {$metricRangeColorScale(histogram[0].metric ?? 0)}"
 				on:click={() => setSelection(true)}
 				on:keydown={() => setSelection(true)}
 			>
@@ -55,11 +55,11 @@
 		</div>
 		<div style:width="{widthScale(histogram[1].filteredCount ?? 0)}%">
 			<div
-				class="flex px-1 py-2.5 cursor-pointer flex-col items-center box-border border-2 border-transparent font-bold rounded-r-xl {selectedValue !==
+				class="flex px-1 py-2.5 cursor-pointer flex-col items-center box-border border-2 border-transparent font-bold rounded-r-xl text-background {selectedValue !==
 					null && selectedValue === true
 					? 'border-primary'
 					: ''}"
-				style="color: white; background-color: {$metricRangeColorScale(histogram[1].metric ?? 0)}"
+				style="background-color: {$metricRangeColorScale(histogram[1].metric ?? 0)}"
 				on:click={() => setSelection(false)}
 				on:keydown={() => setSelection(false)}
 			>

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -96,9 +96,8 @@ export const metricRangeColorScale: Readable<(n: number) => string> = derived(
 		const [min, max] = $metricRange;
 		const colorScale = interpolate('#decbe9', '#6a1b9a');
 		return (n: number) => {
-			if (max - min === 0) {
-				return colorScale(0.5);
-			}
+			if (max === Infinity || min === Infinity) return colorScale(1);
+			if (max - min === 0) return colorScale(0.5);
 			return colorScale((n - min) / (max - min));
 		};
 	}


### PR DESCRIPTION
If no metric is selected, the binary metadata background color was black. This has been changed to our primary color to make it match all other histogams.