### PR TITLE
fix: correct chart fetching with project uuid

### DIFF
--- a/backend/zeno_backend/server.py
+++ b/backend/zeno_backend/server.py
@@ -286,6 +286,7 @@ def get_server() -> FastAPI:
 
     @api_app.get(
         "/project-uuid/{owner_name}/{project_name}",
+        response_model=str,
         dependencies=[Depends(auth)],
         tags=["zeno"],
     )

--- a/frontend/src/lib/zenoapi/services/ZenoService.ts
+++ b/frontend/src/lib/zenoapi/services/ZenoService.ts
@@ -385,10 +385,10 @@ export class ZenoService {
 	 * Get Project Uuid
 	 * @param ownerName
 	 * @param projectName
-	 * @returns any Successful Response
+	 * @returns string Successful Response
 	 * @throws ApiError
 	 */
-	public static getProjectUuid(ownerName: string, projectName: string): CancelablePromise<any> {
+	public static getProjectUuid(ownerName: string, projectName: string): CancelablePromise<string> {
 		return __request(OpenAPI, {
 			method: 'GET',
 			url: '/project-uuid/{owner_name}/{project_name}',

--- a/frontend/src/routes/(app)/project/[owner]/[project]/chart/+page.server.ts
+++ b/frontend/src/routes/(app)/project/[owner]/[project]/chart/+page.server.ts
@@ -4,7 +4,8 @@ import { error } from '@sveltejs/kit';
 
 export async function load({ params }) {
 	OpenAPI.BASE = env.PUBLIC_BACKEND_ENDPOINT + '/api';
-	const charts = await ZenoService.getCharts(params.project);
+	const uuid = await ZenoService.getProjectUuid(params.owner, params.project);
+	const charts = await ZenoService.getCharts(uuid);
 	if (!charts) {
 		throw error(404, 'Could not load charts');
 	}

--- a/frontend/src/routes/(app)/project/[owner]/[project]/chart/[chartIndex=integer]/+page.server.ts
+++ b/frontend/src/routes/(app)/project/[owner]/[project]/chart/[chartIndex=integer]/+page.server.ts
@@ -4,12 +4,13 @@ import { error } from '@sveltejs/kit';
 
 export async function load({ params }) {
 	OpenAPI.BASE = env.PUBLIC_BACKEND_ENDPOINT + '/api';
-	const charts = await ZenoService.getCharts(params.project);
+	const uuid = await ZenoService.getProjectUuid(params.owner, params.project);
+	const charts = await ZenoService.getCharts(uuid);
 	const chart = charts.find((chart) => chart.id === parseInt(params.chartIndex));
 	if (!charts || chart === undefined) {
 		throw error(404, 'Could not load charts');
 	}
-	const chartData = await ZenoService.getChartData(params.project, chart);
+	const chartData = await ZenoService.getChartData(uuid, chart);
 	if (!chartData) {
 		throw error(404, 'Could not load chart data');
 	}


### PR DESCRIPTION
# Description
Since the project parameter changed with our change of referencing projects as owner/project, charts now need to first fetch the project uuid before being fetched.