### PR TITLE
fix: remove key in compare table

### DIFF
--- a/frontend/src/lib/components/instance-views/ComparisonView.svelte
+++ b/frontend/src/lib/components/instance-views/ComparisonView.svelte
@@ -263,7 +263,7 @@
 				</th>
 			</thead>
 			<tbody>
-				{#each table as tableContent (tableContent['dataId'])}
+				{#each table as tableContent}
 					<tr>
 						{#if $project !== undefined && viewMap[$project.view] !== undefined}
 							<td class="pr-2.5">


### PR DESCRIPTION
# Description
This somehow led to a duplicate keys exception. We might want to bring this back after further investigation.
