### PR TITLE
feat: login/logout header functionality

### DIFF
--- a/frontend/src/lib/components/general/Header.svelte
+++ b/frontend/src/lib/components/general/Header.svelte
@@ -13,6 +13,7 @@
 		mdiCog,
 		mdiCompare,
 		mdiCompassOutline,
+		mdiLogin,
 		mdiLogout
 	} from '@mdi/js';
 	import HeaderIcon from './HeaderIcon.svelte';
@@ -75,20 +76,24 @@
 					on:click={() => (projectEdit = true)}
 				/>
 			{/if}
-			<HeaderIcon
-				pageName={'account'}
-				tooltipContent={'Manage your account'}
-				icon={mdiAccount}
-				on:click={() => goto(`/account`)}
-			/>
-			<form method="POST" action="/logout">
+			{#if $authToken}
 				<HeaderIcon
-					pageName={'logout'}
-					tooltipContent={'Logout'}
-					icon={mdiLogout}
-					on:click={() => authToken.set(undefined)}
+					pageName={'account'}
+					tooltipContent={'Manage your account'}
+					icon={mdiAccount}
+					on:click={() => goto(`/account`)}
 				/>
-			</form>
+				<form method="POST" action="/logout">
+					<HeaderIcon pageName={'logout'} tooltipContent={'Logout'} icon={mdiLogout} />
+				</form>
+			{:else}
+				<HeaderIcon
+					pageName={'login'}
+					tooltipContent={'Login'}
+					icon={mdiLogin}
+					on:click={() => goto(`/login`)}
+				/>
+			{/if}
 		</div>
 	</header>
 </nav>

--- a/frontend/src/routes/(user)/logout/+page.server.ts
+++ b/frontend/src/routes/(user)/logout/+page.server.ts
@@ -3,6 +3,6 @@ import { redirect, type Actions } from '@sveltejs/kit';
 export const actions: Actions = {
 	default: async ({ cookies }) => {
 		cookies.delete('loggedIn', { path: '/' });
-		throw redirect(303, '/');
+		throw redirect(303, '/login');
 	}
 };

--- a/frontend/src/routes/(user)/logout/+page.server.ts
+++ b/frontend/src/routes/(user)/logout/+page.server.ts
@@ -3,6 +3,6 @@ import { redirect, type Actions } from '@sveltejs/kit';
 export const actions: Actions = {
 	default: async ({ cookies }) => {
 		cookies.delete('loggedIn', { path: '/' });
-		throw redirect(303, '/login');
+		throw redirect(303, '/');
 	}
 };


### PR DESCRIPTION
# Description

Show a login button when logged out on home screen. Only show account management button when logged in.

Fixes: https://linear.app/zenoml/issue/ZEN-84/fix-login-flow-and-options

Logged in:
<img width="138" alt="Screenshot 2023-09-04 at 10 42 03" src="https://github.com/Sparkier/zeno_hub/assets/4563691/e09fd9ad-0a8e-4266-9816-5517e74e669d">

Logged out:
<img width="138" alt="Screenshot 2023-09-04 at 10 41 47" src="https://github.com/Sparkier/zeno_hub/assets/4563691/fe6fc8d4-29b0-4b8e-a065-08b1bd83ebc4">
