### PR TITLE
fix: inconsistent server updates, don't run get after post, fix tags, 

### DIFF
--- a/backend/zeno_backend/database/insert.py
+++ b/backend/zeno_backend/database/insert.py
@@ -316,31 +316,40 @@ def system(
         db.commit()
 
 
-def folder(project: str, name: str):
+def folder(project: str, name: str) -> int | None:
     """Adding a folder to an existing project.
 
     Args:
         project (str): the project the user is currently working with.
         name (str): name of the folder to be added.
+
+
+    Returns:
+        int | None: the id of the newly created folder.
     """
     db = Database()
-    db.connect_execute(
-        "INSERT INTO folders (name, project_uuid) VALUES (%s,%s);",
+    id = db.connect_execute_return(
+        "INSERT INTO folders (name, project_uuid) VALUES (%s,%s) RETURNING id;",
         [name, project],
     )
+    if id is not None and len(id) > 0:
+        return id[0][0]
 
 
-def slice(project: str, req: Slice):
+def slice(project: str, req: Slice) -> int | None:
     """Add a slice to an existing project.
 
     Args:
         project (str): the project the user is currently working with.
         req (Slice): the slice to be added to the project.
+
+    Returns:
+        int | None: the id of the newly created slice.
     """
     db = Database()
-    db.connect_execute(
+    ids = db.connect_execute_return(
         "INSERT INTO slices (name, folder_id, filter, project_uuid) "
-        "VALUES (%s,%s,%s,%s);",
+        "VALUES (%s,%s,%s,%s) RETURNING id;",
         [
             req.slice_name,
             req.folder_id,
@@ -348,19 +357,27 @@ def slice(project: str, req: Slice):
             project,
         ],
     )
+    if ids is not None:
+        return ids[0][0]
+    else:
+        return None
 
 
-def chart(project: str, chart: Chart):
+def chart(project: str, chart: Chart) -> int | None:
     """Add a chart to an existing project.
 
     Args:
         project (str): the project the user is currently working with.
         chart (Chart): the chart to be added to the project.
+    
+
+    Returns:
+        int | None: the id of the newly created chart.
     """
     db = Database()
-    db.connect_execute(
+    id = db.connect_execute_return(
         "INSERT INTO charts (name, type, parameters, project_uuid) "
-        "VALUES (%s,%s,%s,%s);",
+        "VALUES (%s,%s,%s,%s) RETURNING id;",
         [
             chart.name,
             chart.type,
@@ -368,14 +385,19 @@ def chart(project: str, chart: Chart):
             project,
         ],
     )
+    if id is not None and len(id) > 0:
+        return id[0][0]
 
 
-def tag(project: str, tag: Tag):
+def tag(project: str, tag: Tag) -> int | None:
     """Add a tag to an existing project.
 
     Args:
         project (str): the project the user is currently working with.
         tag (Tag): the tag to be added to the project.
+
+    Returns:
+        int | None: the id of the newly created tag.
     """
     with Database() as db:
         id = db.execute_return(
@@ -383,16 +405,17 @@ def tag(project: str, tag: Tag):
             "RETURNING id;",
             [tag.tag_name, tag.folder_id, project],
         )
-        if id is None:
+        if id is None or len(id) == 0:
             return
         for datapoint in tag.data_ids:
             db.execute(
                 sql.SQL("INSERT INTO {} (tag_id, data_id) VALUES (%s,%s);").format(
                     sql.Identifier(f"{project}_tags_datapoints")
                 ),
-                [id[0], datapoint],
+                [id[0][0], datapoint],
             )
         db.commit()
+        return id[0][0]
 
 
 def user(user: User):

--- a/backend/zeno_backend/database/insert.py
+++ b/backend/zeno_backend/database/insert.py
@@ -369,7 +369,7 @@ def chart(project: str, chart: Chart) -> int | None:
     Args:
         project (str): the project the user is currently working with.
         chart (Chart): the chart to be added to the project.
-    
+
 
     Returns:
         int | None: the id of the newly created chart.

--- a/backend/zeno_backend/database/select.py
+++ b/backend/zeno_backend/database/select.py
@@ -832,7 +832,7 @@ def tags(project: str) -> list[Tag]:
                     folder_id=tag_result[2],
                     data_ids=[]
                     if len(data_results) == 0
-                    else list(map(lambda d: d[0], data_results[0])),
+                    else [d[0] for d in data_results],
                 )
             )
         return tags

--- a/backend/zeno_backend/database/update.py
+++ b/backend/zeno_backend/database/update.py
@@ -95,7 +95,7 @@ def tag(tag: Tag, project: str):
                 tag.id,
             ],
         )
-        if len(data_ids_result) == 0:
+        if data_ids_result is None:
             return
 
         existing_data = set(map(lambda d: d[0], data_ids_result))

--- a/backend/zeno_backend/server.py
+++ b/backend/zeno_backend/server.py
@@ -248,7 +248,7 @@ def get_server() -> FastAPI:
         # Prepend the DATA_URL to the data column if it exists
         project = select.project_from_uuid(project_uuid)
         if project and project.data_url:
-            filt_df["data_id"] = project.data_url + filt_df["data_id"]
+            filt_df["data"] = project.data_url + filt_df["data"]
 
         if req.diff_column_1 and req.diff_column_2:
             filt_df = generate_diff_cols(
@@ -455,21 +455,65 @@ def get_server() -> FastAPI:
         else:
             return fetched_user
 
-    @api_app.post("/folder/{project}", tags=["zeno"], dependencies=[Depends(auth)])
+    @api_app.post(
+        "/folder/{project}",
+        response_model=int,
+        tags=["zeno"],
+        dependencies=[Depends(auth)],
+    )
     def add_folder(project: str, name: str):
-        insert.folder(project, name)
+        id = insert.folder(project, name)
+        if id is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to insert folder",
+            )
+        return id
 
-    @api_app.post("/slice/{project}", tags=["zeno"], dependencies=[Depends(auth)])
+    @api_app.post(
+        "/slice/{project}",
+        response_model=int,
+        tags=["zeno"],
+        dependencies=[Depends(auth)],
+    )
     def add_slice(project: str, req: Slice):
-        insert.slice(project, req)
+        res = insert.slice(project, req)
+        if res is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to insert slice",
+            )
+        return res
 
-    @api_app.post("/chart/{project}", tags=["zeno"], dependencies=[Depends(auth)])
+    @api_app.post(
+        "/chart/{project}",
+        response_model=int,
+        tags=["zeno"],
+        dependencies=[Depends(auth)],
+    )
     def add_chart(project: str, chart: Chart):
-        insert.chart(project, chart)
+        id = insert.chart(project, chart)
+        if id is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to insert chart",
+            )
+        return id
 
-    @api_app.post("/tag/{project}", tags=["zeno"], dependencies=[Depends(auth)])
+    @api_app.post(
+        "/tag/{project}",
+        response_model=int,
+        tags=["zeno"],
+        dependencies=[Depends(auth)],
+    )
     def add_tag(tag: Tag, project: str):
-        insert.tag(project, tag)
+        id = insert.tag(project, tag)
+        if id is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to insert tag",
+            )
+        return id
 
     @api_app.post("/add-organization", tags=["zeno"], dependencies=[Depends(auth)])
     def add_organization(user: User, organization: Organization):

--- a/backend/zeno_backend/server.py
+++ b/backend/zeno_backend/server.py
@@ -477,13 +477,13 @@ def get_server() -> FastAPI:
         dependencies=[Depends(auth)],
     )
     def add_slice(project: str, req: Slice):
-        res = insert.slice(project, req)
-        if res is None:
+        id = insert.slice(project, req)
+        if id is None:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to insert slice",
             )
-        return res
+        return id
 
     @api_app.post(
         "/chart/{project}",

--- a/frontend/src/lib/components/chart/ChartHomeBlock.svelte
+++ b/frontend/src/lib/components/chart/ChartHomeBlock.svelte
@@ -9,7 +9,7 @@
 		mdiViewGrid
 	} from '@mdi/js';
 
-	import { goto } from '$app/navigation';
+	import { goto, invalidateAll } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { charts, project } from '$lib/stores';
 	import { clickOutside } from '$lib/util/clickOutside';
@@ -69,10 +69,17 @@
 										name: 'Copy of ' + chart.name,
 										type: chart.type,
 										parameters: chart.parameters
-									}).then(() => {
-										ZenoService.getCharts($project ? $project.uuid : '').then((fetchedCharts) =>
-											charts.set(fetchedCharts)
-										);
+									}).then((res) => {
+										invalidateAll();
+										charts.update((c) => {
+											c.push({
+												id: res,
+												name: 'Copy of ' + chart.name,
+												type: chart.type,
+												parameters: chart.parameters
+											});
+											return c;
+										});
 									});
 								}}
 							>
@@ -86,9 +93,8 @@
 									e.stopPropagation();
 									showOptions = false;
 									ZenoService.deleteChart(chart).then(() => {
-										ZenoService.getCharts($project ? $project.uuid : '').then((fetchedCharts) =>
-											charts.set(fetchedCharts)
-										);
+										invalidateAll();
+										charts.update((c) => c.filter((c) => c.id != chart.id));
 									});
 								}}
 							>

--- a/frontend/src/lib/components/instance-views/ComparisonView.svelte
+++ b/frontend/src/lib/components/instance-views/ComparisonView.svelte
@@ -87,7 +87,7 @@
 		updateTable();
 	}
 
-	comparisonColumn.subscribe((_) => {
+	comparisonColumn.subscribe(() => {
 		table = undefined;
 		compareSort.set([undefined, true]);
 	});

--- a/frontend/src/lib/components/instance-views/InstanceView.svelte
+++ b/frontend/src/lib/components/instance-views/InstanceView.svelte
@@ -54,7 +54,6 @@
 	onMount(() => {
 		if ($project === undefined || $project.view === '') {
 			selected = 'table';
-			return;
 		}
 	});
 

--- a/frontend/src/lib/components/instance-views/views/views/AudioTranscription.svelte
+++ b/frontend/src/lib/components/instance-views/views/views/AudioTranscription.svelte
@@ -2,7 +2,7 @@
 	export let entry: Record<string, number | string | boolean>;
 	export let modelColumn: string;
 
-	$: audioURL = entry['data_id'] as string;
+	$: audioURL = entry['data'] as string;
 </script>
 
 <div class="p-4 border border-grey-lighter max-w-[450px] min-w-[400px] rounded">

--- a/frontend/src/lib/components/metadata/MetadataHeader.svelte
+++ b/frontend/src/lib/components/metadata/MetadataHeader.svelte
@@ -15,12 +15,6 @@
 	let comparisonColumnOptions: ZenoColumn[] = [];
 
 	onMount(() => {
-		if ($model === undefined && $models.length > 0) {
-			model.set($models[0]);
-		}
-		if ($metric === undefined && $metrics.length > 0) {
-			metric.set($metrics[0]);
-		}
 		comparisonColumnOptions = $columns.filter((c) => c.model === $model);
 		comparisonColumn.set(comparisonColumnOptions[0]);
 	});

--- a/frontend/src/lib/components/metadata/Slices.svelte
+++ b/frontend/src/lib/components/metadata/Slices.svelte
@@ -59,7 +59,7 @@
 	{#each $folders as folder}
 		<FolderCell {folder} />
 	{/each}
-	{#each $slices.filter((s) => s.folderId === null && s.sliceName !== 'All Instances') as s (s.sliceName)}
+	{#each $slices.filter((s) => s.folderId === null || s.folderId === undefined) as s (s.sliceName)}
 		<SliceCell compare={$page.url.href.includes('compare')} slice={s} />
 	{/each}
 </div>

--- a/frontend/src/lib/components/metadata/Tags.svelte
+++ b/frontend/src/lib/components/metadata/Tags.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { invalidateAll } from '$app/navigation';
 	import { page } from '$app/stores';
 	import { editTag, editedIds, project, selectionIds, selections, tagIds, tags } from '$lib/stores';
 	import { ZenoService, type Tag } from '$lib/zenoapi';
@@ -13,20 +14,26 @@
 
 	function saveChanges() {
 		if ($editTag === undefined || $project === undefined) return;
-		ZenoService.updateTag($project.uuid, { ...$editTag, dataIds: $editedIds }).then(() => {
+		ZenoService.updateTag($project.uuid, {
+			...$editTag,
+			dataIds: Array.from(new Set([...$editTag.dataIds, ...$editedIds]))
+		}).then(() => {
+			invalidateAll();
+			tags.update((t) => {
+				const index = t.findIndex((tag) => tag.id === $editTag?.id);
+				if (index !== -1 && $editTag !== undefined) {
+					t[index] = { ...$editTag, dataIds: $editedIds };
+				}
+				return t;
+			});
+			let s = new Set<string>();
+			$selections.tags.forEach((tagId) => {
+				const tag: Tag | undefined = $tags.find((cur) => cur.id === tagId);
+				if (tag !== undefined) tag.dataIds.forEach((item) => s.add(item));
+				tagIds.set([...s]);
+			});
 			editTag.set(undefined);
 			editedIds.set([]);
-			if ($project !== undefined) {
-				ZenoService.getTags($project.uuid).then((fetchedTags) => {
-					tags.set(fetchedTags);
-					let s = new Set<string>();
-					$selections.tags.forEach((tagId) => {
-						const tag: Tag | undefined = $tags.find((cur) => cur.id === tagId);
-						if (tag !== undefined) tag.dataIds.forEach((item) => s.add(item));
-						tagIds.set([...s]);
-					});
-				});
-			}
 		});
 	}
 </script>
@@ -79,13 +86,15 @@
 	{#each [...$tags.values()] as t}
 		{#if $editTag !== undefined && $editTag.id === t.id}
 			<div style="display: flex; align-items: center">
-				<div class="mr-2">
+				<div class="mr-2 w-full">
 					<TagCell tag={t} />
 				</div>
 				<Button
 					style="background-color: var(--N1); margin-top: 5px; color: white; "
-					on:click={saveChanges}>Done</Button
+					on:click={saveChanges}
 				>
+					Done
+				</Button>
 			</div>
 		{:else}
 			<TagCell tag={t} />

--- a/frontend/src/lib/components/metadata/cells/SliceFinderCell.svelte
+++ b/frontend/src/lib/components/metadata/cells/SliceFinderCell.svelte
@@ -46,7 +46,7 @@
 	function removeSlice() {
 		ZenoService.deleteSlice(slice).then(() => {
 			invalidateAll();
-			slices.update((s) => s.filter((sli) => sli.sliceName !== slice.sliceName));
+			slices.update((s) => s.filter((sli) => sli.id !== slice.id));
 			created = false;
 		});
 	}

--- a/frontend/src/lib/components/metadata/cells/TagCell.svelte
+++ b/frontend/src/lib/components/metadata/cells/TagCell.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+	import { invalidateAll } from '$app/navigation';
 	import { getMetricsForTags } from '$lib/api/tag';
-	import { editTag, metric, model, project, selections, tagIds, tags } from '$lib/stores';
+	import { editTag, metric, model, selections, tagIds, tags } from '$lib/stores';
 	import { clickOutside } from '$lib/util/clickOutside';
 	import { Join, ZenoService, type Tag, type TagMetricKey } from '$lib/zenoapi';
 	import { mdiDotsHorizontal } from '@mdi/js';
@@ -27,9 +28,8 @@
 			return { slices: [], metadata: { ...m.metadata }, tags: [] };
 		});
 		ZenoService.deleteTag(tag).then(() => {
-			if ($project !== undefined) {
-				ZenoService.getTags($project.uuid).then((fetchedTags) => tags.set(fetchedTags));
-			}
+			invalidateAll();
+			tags.update((t) => t.filter((t) => t.id !== tag.id));
 		});
 		tagIds.set([]);
 	}
@@ -193,13 +193,15 @@
 				</div>
 			{/if}
 			{#await result then res}
-				{#if res !== null}
-					<span class="mr-2">
+				{#if res !== null && tag.dataIds.length > 0}
+					<span class="mr-2 w-full">
 						{res.metric !== undefined && res.metric !== null ? res.metric.toFixed(2) : ''}
 					</span>
 					<span class="italic text-grey-darker mr-1">
 						({res.size.toLocaleString()})
 					</span>
+				{:else}
+					<span class="italic text-grey-darker mr-1"> (0) </span>
 				{/if}
 			{/await}
 			{#if $editTag === undefined || $editTag.id !== tag.id}

--- a/frontend/src/lib/components/metadata/chips/TagChip.svelte
+++ b/frontend/src/lib/components/metadata/chips/TagChip.svelte
@@ -25,6 +25,6 @@
 </script>
 
 <div class="px-2.5 py-1 bg-greenish-light mx-1 my rounded-lg w-fit">
-	{tagId}
+	{$tags.find((tag) => tag.id === tagId)?.tagName}
 	<TrailingIcon class="remove material-icons" on:click={cancelClicked}>cancel</TrailingIcon>
 </div>

--- a/frontend/src/lib/components/popups/FolderPopup.svelte
+++ b/frontend/src/lib/components/popups/FolderPopup.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { invalidateAll } from '$app/navigation';
 	import { folders, project } from '$lib/stores';
 	import { ZenoService, type Folder } from '$lib/zenoapi';
 	import Button from '@smui/button';
@@ -26,11 +27,14 @@
 				...folderToEdit,
 				name: folderName
 			}).then(() => {
-				if ($project) {
-					ZenoService.getFolders($project.uuid).then((fetchedFolders) =>
-						folders.set(fetchedFolders)
-					);
-				}
+				invalidateAll();
+				folders.update((f) => {
+					const index = f.findIndex((f) => f.id === folderToEdit?.id);
+					if (index !== -1 && folderToEdit) {
+						f[index] = { ...folderToEdit, name: folderName };
+					}
+					return f;
+				});
 			});
 		}
 		dispatch('close');
@@ -39,12 +43,15 @@
 	/** Create a folder using the folderName variable **/
 	function createFolder() {
 		if ($project) {
-			ZenoService.addFolder($project.uuid, folderName).then(() => {
-				if ($project) {
-					ZenoService.getFolders($project.uuid).then((fetchedFolders) =>
-						folders.set(fetchedFolders)
-					);
-				}
+			ZenoService.addFolder($project.uuid, folderName).then((res) => {
+				invalidateAll();
+				folders.update((f) => [
+					...f,
+					{
+						id: res,
+						name: folderName
+					}
+				]);
 			});
 		}
 		dispatch('close');

--- a/frontend/src/lib/components/popups/SlicePopup.svelte
+++ b/frontend/src/lib/components/popups/SlicePopup.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { invalidateAll } from '$app/navigation';
 	import { columns, project, selectionPredicates, selections, slices } from '$lib/stores';
 	import { isPredicateGroup } from '$lib/util/typeCheck';
 	import {
@@ -113,6 +114,18 @@
 				sliceName,
 				filterPredicates: predicateGroup,
 				folderId: folderId
+			}).then(() => {
+				slices.update((s) => {
+					const index = s.findIndex((slice) => slice.id === sliceToEdit?.id);
+					s[index] = {
+						id: sliceToEdit ? sliceToEdit.id : -1,
+						sliceName,
+						filterPredicates: predicateGroup,
+						folderId: folderId
+					};
+					return s;
+				});
+				invalidateAll();
 			});
 		} else {
 			ZenoService.addSlice($project ? $project.uuid : '', {
@@ -120,18 +133,25 @@
 				sliceName,
 				filterPredicates: predicateGroup,
 				folderId: folderId
-			}).then(() => {
-				ZenoService.getSlices($project ? $project.uuid : '').then((fetchedSlices) => {
-					slices.set(fetchedSlices);
-					selections.update(() => ({
-						slices: [],
-						metadata: {},
-						tags: []
-					}));
-					dispatch('close');
-				});
+			}).then((res) => {
+				invalidateAll();
+				slices.update((s) => [
+					...s,
+					{
+						id: res,
+						sliceName,
+						filterPredicates: predicateGroup,
+						folderId: folderId
+					}
+				]);
+				selections.update(() => ({
+					slices: [],
+					metadata: {},
+					tags: []
+				}));
 			});
 		}
+		dispatch('close');
 	}
 
 	function submit(e: KeyboardEvent) {

--- a/frontend/src/lib/components/popups/TagPopup.svelte
+++ b/frontend/src/lib/components/popups/TagPopup.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { invalidateAll } from '$app/navigation';
 	import { project, selectionIds, tags } from '$lib/stores';
 	import { ZenoService } from '$lib/zenoapi';
 	import Button from '@smui/button';
@@ -31,13 +32,17 @@
 				id: 0,
 				tagName,
 				dataIds: []
-			}).then(() => {
-				if ($project !== undefined) {
-					ZenoService.getTags($project.uuid).then((fetchedTags) => {
-						tags.set(fetchedTags);
-						dispatch('close');
-					});
-				}
+			}).then((res) => {
+				invalidateAll();
+				tags.update((t) => [
+					...t,
+					{
+						id: res,
+						tagName,
+						dataIds: []
+					}
+				]);
+				dispatch('close');
 			});
 		}
 	}

--- a/frontend/src/routes/(app)/project/[owner]/[project]/+layout.server.ts
+++ b/frontend/src/routes/(app)/project/[owner]/[project]/+layout.server.ts
@@ -1,5 +1,13 @@
 import { getEndpoint } from '$lib/util/util';
-import { OpenAPI, ZenoService } from '$lib/zenoapi/index.js';
+import {
+	OpenAPI,
+	ZenoService,
+	type Folder,
+	type Metric,
+	type Slice,
+	type Tag,
+	type ZenoColumn
+} from '$lib/zenoapi/index.js';
 import { error, redirect } from '@sveltejs/kit';
 
 export async function load({ cookies, params, url }) {
@@ -26,39 +34,26 @@ export async function load({ cookies, params, url }) {
 	if (!project) {
 		throw error(404, 'Could not load project config');
 	}
-	const slices = await ZenoService.getSlices(project.uuid);
-	if (!slices) {
-		throw error(404, 'Could not load slices');
-	}
-	const columns = await ZenoService.getColumns(project.uuid);
-	if (!columns) {
-		throw error(404, 'Could not load columns');
-	}
-	const models = await ZenoService.getModels(project.uuid);
-	if (!slices) {
-		throw error(404, 'Could not load models');
-	}
-	const metrics = await ZenoService.getMetrics(project.uuid);
-	if (!metrics) {
-		throw error(404, 'Could not load metrics');
-	}
-	const folders = await ZenoService.getFolders(project.uuid);
-	if (!folders) {
-		throw error(404, 'Could not load folders');
-	}
-	const tags = await ZenoService.getTags(project.uuid);
-	if (!tags) {
-		throw error(404, 'Could not load tags');
-	}
+
+	const requests = [
+		ZenoService.getSlices(project.uuid),
+		ZenoService.getColumns(project.uuid),
+		ZenoService.getModels(project.uuid),
+		ZenoService.getMetrics(project.uuid),
+		ZenoService.getFolders(project.uuid),
+		ZenoService.getTags(project.uuid)
+	];
+
+	const results = await Promise.all(requests);
 
 	return {
 		project: project,
-		slices: slices,
-		columns: columns,
-		models: models,
-		metrics: metrics,
-		folders: folders,
-		tags: tags,
+		slices: results[0] as Slice[],
+		columns: results[1] as ZenoColumn[],
+		models: results[2] as string[],
+		metrics: results[3] as Metric[],
+		folders: results[4] as Folder[],
+		tags: results[5] as Tag[],
 		cognitoUser: cognitoUser
 	};
 }

--- a/frontend/src/routes/(app)/project/[owner]/[project]/+layout.svelte
+++ b/frontend/src/routes/(app)/project/[owner]/[project]/+layout.svelte
@@ -2,7 +2,9 @@
 	import {
 		columns,
 		folders,
+		metric,
 		metrics,
+		model,
 		models,
 		project,
 		rowsPerPage,
@@ -14,23 +16,27 @@
 
 	export let data;
 
-	$: setupProject(data);
+	project.set(data.project);
+	rowsPerPage.set(data.project.samplesPerPage ?? 10);
+	slices.set(data.slices);
+	columns.set(data.columns);
+	models.set(data.models);
+	if (data.models.length > 0) {
+		model.set(data.models[0]);
+	}
+	metrics.set(data.metrics);
+	if (data.metrics.length > 0) {
+		metric.set(data.metrics[0]);
+	}
+	folders.set(data.folders);
+	tags.set(data.tags);
 
-	function setupProject(setup_data: any) {
-		project.set(setup_data.project);
-		rowsPerPage.set(setup_data.project.samplesPerPage ?? 5);
-		slices.set(setup_data.slices);
-		columns.set(setup_data.columns);
-		models.set(setup_data.models);
-		metrics.set(setup_data.metrics);
-		folders.set(setup_data.folders);
-		tags.set(setup_data.tags);
-		zenoAPI.BASE = `${getEndpoint()}/api`;
-		if (setup_data.cognitoUser) {
-			zenoAPI.HEADERS = {
-				Authorization: 'Bearer ' + setup_data.cognitoUser.accessToken
-			};
-		}
+	zenoAPI.BASE = `${getEndpoint()}/api`;
+
+	if (data.cognitoUser) {
+		zenoAPI.HEADERS = {
+			Authorization: 'Bearer ' + data.cognitoUser.accessToken
+		};
 	}
 </script>
 

--- a/frontend/src/routes/(app)/project/[owner]/[project]/chart/+page.svelte
+++ b/frontend/src/routes/(app)/project/[owner]/[project]/chart/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
+	import { goto, invalidateAll } from '$app/navigation';
 	import ChartHomeBlock from '$lib/components/chart/ChartHomeBlock.svelte';
 	import { chartDefaults } from '$lib/components/chart/chartUtil';
 	import { project } from '$lib/stores';
@@ -30,15 +30,15 @@
 					ZenoService.addChart(
 						$project ? $project.uuid : '',
 						chartDefaults('New Chart', 0, ChartType.BAR)
-					).then(() => {
-						ZenoService.getCharts($project ? $project.uuid : '').then((fetchedCharts) => {
-							charts.set(fetchedCharts);
-							goto(
-								`/project/${$project ? $project.ownerName : ''}/${
-									$project ? $project.name : ''
-								}/chart/${fetchedCharts[fetchedCharts.length - 1].id}?edit=true`
-							);
-						});
+					).then((res) => {
+						invalidateAll();
+						charts.update((c) => [...c, chartDefaults('New Chart', res, ChartType.BAR)]);
+
+						goto(
+							`/project/${$project ? $project.ownerName : ''}/${
+								$project ? $project.name : ''
+							}/chart/${$charts[$charts.length - 1].id}?edit=true`
+						);
 					});
 				}}
 			>

--- a/frontend/src/routes/(app)/project/[owner]/[project]/chart/[chartIndex=integer]/+page.svelte
+++ b/frontend/src/routes/(app)/project/[owner]/[project]/chart/[chartIndex=integer]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
+	import { invalidateAll } from '$app/navigation';
 	import { page } from '$app/stores';
 	import ChartContainer from '$lib/components/chart/ChartContainer.svelte';
 	import EditHeader from '$lib/components/chart/chart-page/chart-header/EditHeader.svelte';
@@ -38,8 +39,14 @@
 	function updateChart(chart: Chart) {
 		if ($project) {
 			ZenoService.updateChart($project.uuid, chart).then(() => {
-				if ($project)
-					ZenoService.getCharts($project.uuid).then((fetchedCharts) => charts.set(fetchedCharts));
+				invalidateAll();
+				charts.update((c) => {
+					let index = c.findIndex((c) => c.id === chart.id);
+					if (index !== -1) {
+						c[index] = chart;
+					}
+					return c;
+				});
 			});
 		}
 	}


### PR DESCRIPTION
# Description
Sveltekit was caching get requests for things like slices, causing it to not re-pull changes when tabs were changed. This is primarily fixed by calling `invalidateAll()`. This PR fixes that along with some other fixes/changes:

* Don't call get after post, just return ID and add locally for "post" calls
* Run initial fetch in parallel for performance
* Fix what is used to render data to separate from data_id for tags

Fixes:
[ZEN-92 : slices are not always updated on the frontend without refresh](https://linear.app/zenoml/issue/ZEN-92/slices-are-not-always-updated-on-the-frontend-without-refresh)
[ZEN-96 : metric dropdown is blank when navigating home and back to a project](https://linear.app/zenoml/issue/ZEN-96/metric-dropdown-is-blank-when-navigating-home-and-back-to-a-project)