### PR TITLE
fix: do metadata chart selection in frontend

### DIFF
--- a/backend/zeno_backend/database/util.py
+++ b/backend/zeno_backend/database/util.py
@@ -24,9 +24,7 @@ def resolve_metadata_type(data_frame: pd.DataFrame, column: str) -> MetadataType
     elif pd.api.types.is_datetime64_any_dtype(dtype):
         return MetadataType.DATETIME
     elif pd.api.types.is_string_dtype(dtype):
-        if data_frame[column].nunique() < 20:
-            return MetadataType.NOMINAL
-        return MetadataType.OTHER
+        return MetadataType.NOMINAL
     return MetadataType.OTHER
 
 

--- a/frontend/src/lib/api/metadata.ts
+++ b/frontend/src/lib/api/metadata.ts
@@ -47,9 +47,7 @@ export async function getHistograms(
 	const res = await ZenoService.getHistogramBuckets(config.uuid, requestedHistograms);
 	requestingHistogramCounts.set(false);
 	const histograms = new Map<string, HistogramEntry[]>(
-		[
-			...new Map<string, HistogramEntry[]>(requestedHistograms.map((col, i) => [col.id, res[i]]))
-		].filter((el) => el[1].length < 30)
+		requestedHistograms.map((col, i) => [col.id, res[i]])
 	);
 	return histograms;
 }

--- a/frontend/src/lib/components/metadata/cells/MetadataCell.svelte
+++ b/frontend/src/lib/components/metadata/cells/MetadataCell.svelte
@@ -41,6 +41,14 @@
 			tags: mets.tags
 		}));
 	}
+
+	function getChartType(dataType: MetadataType, histogram: HistogramEntry[]) {
+		if (dataType === MetadataType.NOMINAL && histogram.length >= 20) {
+			return columnMap[MetadataType.OTHER];
+		} else {
+			return columnMap[dataType];
+		}
+	}
 </script>
 
 {#if histogram}
@@ -53,7 +61,7 @@
 			</div>
 		</div>
 		<svelte:component
-			this={columnMap[col.dataType]}
+			this={getChartType(col.dataType, histogram)}
 			filterPredicates={predicates}
 			{updatePredicates}
 			{col}


### PR DESCRIPTION
# Description
Shift chart selection to frontend, don't filter out histograms.

Original suggestion by @Sparkier , think its better, easier to update frontend visualizations in the future.