### PR TITLE
fix: move references to amplitude key to after .env loading

### DIFF
--- a/backend/zeno_backend/routers/sdk.py
+++ b/backend/zeno_backend/routers/sdk.py
@@ -20,8 +20,6 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from zeno_backend.classes.project import Project
 from zeno_backend.database import insert, select
 
-amplitude_client = Amplitude(os.environ["AMPLITUDE_API_KEY"])
-
 
 class APIKeyBearer(HTTPBearer):
     """API key bearer authentication scheme."""
@@ -97,6 +95,7 @@ def create_project(project: Project, api_key=Depends(APIKeyBearer())):
         )
 
     project.uuid = str(uuid.uuid4())
+    amplitude_client = Amplitude(os.environ["AMPLITUDE_API_KEY"])
     amplitude_client.track(
         BaseEvent(
             event_type="Project Created",
@@ -197,6 +196,7 @@ def upload_system(
             detail=("ERROR: Unable to create system table: " + str(e)),
         ) from e
 
+    amplitude_client = Amplitude(os.environ["AMPLITUDE_API_KEY"])
     amplitude_client.track(
         BaseEvent(
             event_type="System Uploaded",

--- a/backend/zeno_backend/server.py
+++ b/backend/zeno_backend/server.py
@@ -44,8 +44,6 @@ from zeno_backend.processing.util import generate_diff_cols
 
 from .routers import sdk
 
-amplitude_client = Amplitude(os.environ["AMPLITUDE_API_KEY"])
-
 
 def get_server() -> FastAPI:
     """Provide the FastAPI server and specifies its inputs.
@@ -64,6 +62,8 @@ def get_server() -> FastAPI:
     env_path = Path("../frontend/.env")
     if env_path.exists():
         load_dotenv(env_path)
+
+    amplitude_client = Amplitude(os.environ["AMPLITUDE_API_KEY"])
 
     # function to get the user from cognito
     auth = Cognito(


### PR DESCRIPTION
Previously, the environment variable containing the amplitude API key was referenced before loading the .env file. This has been changed so that the key does not have to be set outside the .env file.
