### PR TITLE
refactor: remove project undefined checks

### DIFF
--- a/frontend/src/lib/components/chart/ChartHomeBlock.svelte
+++ b/frontend/src/lib/components/chart/ChartHomeBlock.svelte
@@ -72,11 +72,11 @@
 								on:click={(e) => {
 									e.stopPropagation();
 									showOptions = false;
-									ZenoService.addChart($project ? $project.uuid : '', {
+									ZenoService.addChart($project.uuid, {
 										id: 0,
 										name: 'Copy of ' + chart.name,
 										type: chart.type,
-										projectUuid: $project ? $project.uuid : '',
+										projectUuid: $project.uuid,
 										parameters: chart.parameters
 									}).then(() => invalidate('app:charts'));
 								}}

--- a/frontend/src/lib/components/chart/chart-page/chart-header/ViewHeader.svelte
+++ b/frontend/src/lib/components/chart/chart-page/chart-header/ViewHeader.svelte
@@ -39,7 +39,7 @@
 		</SmuiElement>
 		<h4 class="text-grey-dark hover:text-black mr-4">Back to Chart Home</h4>
 	</div>
-	{#if $project?.editor}
+	{#if $project.editor}
 		<Button
 			variant="raised"
 			on:mouseleave={blur}

--- a/frontend/src/lib/components/chart/chart-page/view-selection/ViewSelection.svelte
+++ b/frontend/src/lib/components/chart/chart-page/view-selection/ViewSelection.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { project } from '$lib/stores';
 	import { chartDefaults } from '$lib/util/charts';
 	import { ChartType, type Chart } from '$lib/zenoapi';
 	import ChartElement from './ChartElement.svelte';
@@ -7,7 +6,7 @@
 	export let chart: Chart;
 
 	async function updateChart(chartType: ChartType) {
-		if (chart.type !== chartType && $project) {
+		if (chart.type !== chartType) {
 			chart = chartDefaults(chart.name, chart.id, chart.projectUuid, chartType);
 		}
 	}

--- a/frontend/src/lib/components/general/Header.svelte
+++ b/frontend/src/lib/components/general/Header.svelte
@@ -25,7 +25,7 @@
 	$: currentTab = $page.url.href.split('/').pop();
 </script>
 
-{#if projectEdit && $project && user !== null}
+{#if projectEdit && user !== null}
 	<ProjectPopup config={$project} on:close={() => (projectEdit = false)} {user} />
 {/if}
 <nav class="z-20">

--- a/frontend/src/lib/components/instance-views/ComparisonView.svelte
+++ b/frontend/src/lib/components/instance-views/ComparisonView.svelte
@@ -37,7 +37,7 @@
 
 	let sampleOptions = [
 		...new Set(
-			$project !== undefined && $project.samplesPerPage !== undefined
+			$project.samplesPerPage !== undefined
 				? [5, 15, 30, 60, 100, $project.samplesPerPage]
 				: [5, 15, 30, 60, 100]
 		)
@@ -206,7 +206,7 @@
 			<tbody>
 				{#each table as tableContent}
 					<tr>
-						{#if $project !== undefined && viewMap[$project.view] !== undefined}
+						{#if viewMap[$project.view] !== undefined}
 							<td class="p-3 align-baseline">
 								<div class="instance">
 									<svelte:component

--- a/frontend/src/lib/components/instance-views/InstanceView.svelte
+++ b/frontend/src/lib/components/instance-views/InstanceView.svelte
@@ -54,7 +54,7 @@
 		: new Promise(() => undefined);
 
 	onMount(() => {
-		if ($project === undefined || $project.view === '') {
+		if ($project.view === '') {
 			selected = 'table';
 		}
 	});
@@ -104,7 +104,7 @@
 
 <div class="flex justify-between align-center">
 	<SelectionBar bind:selected {currentResult}>
-		{#if $project !== undefined && optionsMap[$project.view] !== undefined}
+		{#if optionsMap[$project.view] !== undefined}
 			<svelte:component this={optionsMap[$project.view]} bind:viewOptions />
 		{/if}
 	</SelectionBar>

--- a/frontend/src/lib/components/instance-views/ListView.svelte
+++ b/frontend/src/lib/components/instance-views/ListView.svelte
@@ -29,7 +29,7 @@
 
 	let sampleOptions = [
 		...new Set(
-			$project !== undefined && $project.samplesPerPage !== undefined
+			$project.samplesPerPage !== undefined
 				? [5, 15, 30, 60, 100, $project.samplesPerPage]
 				: [5, 15, 30, 60, 100]
 		)
@@ -94,7 +94,7 @@
 
 <div class="overflow-y-auto flex flex-wrap content-start w-full h-full">
 	{#await tablePromise then table}
-		{#if $project !== undefined && viewMap[$project.view] !== undefined}
+		{#if viewMap[$project.view] !== undefined}
 			{#each table as inst (inst['data_id'])}
 				<div class="mr-2 mt-2">
 					<svelte:component

--- a/frontend/src/lib/components/instance-views/TableView.svelte
+++ b/frontend/src/lib/components/instance-views/TableView.svelte
@@ -35,7 +35,7 @@
 	let instanceHidden = false;
 	let sampleOptions = [
 		...new Set(
-			$project !== undefined && $project.samplesPerPage !== undefined
+			$project.samplesPerPage !== undefined
 				? [5, 15, 30, 60, 100, $project.samplesPerPage]
 				: [5, 15, 30, 60, 100]
 		)
@@ -125,7 +125,7 @@
 				{#if $editTag !== undefined}
 					<th class="p-3 font-semibold font-grey">Included</th>
 				{/if}
-				{#if $project !== undefined && viewMap[$project.view] !== undefined}
+				{#if viewMap[$project.view] !== undefined}
 					<th
 						class="p-3 font-semibold font-grey whitespace-nowrap"
 						on:click={() => (instanceHidden = !instanceHidden)}
@@ -166,7 +166,7 @@
 								<Checkbox bind:group={currentTagIds} value={String(tableContent['data_id'])} />
 							</td>
 						{/if}
-						{#if $project !== undefined && viewMap[$project.view] !== undefined}
+						{#if viewMap[$project.view] !== undefined}
 							<td class="p-3">
 								{#if instanceHidden}
 									<p class="text-center">...</p>

--- a/frontend/src/lib/components/metadata/Histograms.svelte
+++ b/frontend/src/lib/components/metadata/Histograms.svelte
@@ -37,9 +37,9 @@
 
 	histogramState.subscribe((s) => {
 		if (metadataHistograms.size === 0) {
-			getHistograms($project?.uuid, $columns, $model).then((res) => {
+			getHistograms($project.uuid, $columns, $model).then((res) => {
 				calculateHistograms(
-					$project?.uuid,
+					$project.uuid,
 					$columns,
 					res,
 					s.selectionPredicates,
@@ -52,7 +52,7 @@
 			});
 		} else {
 			calculateHistograms(
-				$project?.uuid,
+				$project.uuid,
 				$columns,
 				metadataHistograms,
 				s.selectionPredicates,

--- a/frontend/src/lib/components/metadata/SelectionBar.svelte
+++ b/frontend/src/lib/components/metadata/SelectionBar.svelte
@@ -11,11 +11,7 @@
 	let CHOICES: string[];
 
 	$: CHOICES =
-		$editTag === undefined
-			? $project !== undefined && $project.view !== ''
-				? ['list', 'table']
-				: ['table']
-			: ['table'];
+		$editTag === undefined ? ($project.view !== '' ? ['list', 'table'] : ['table']) : ['table'];
 </script>
 
 <div class="w-full">
@@ -47,15 +43,13 @@
 				{#if $editTag === undefined}
 					<slot />
 					<Group>
-						{#if $project !== undefined}
-							{#each CHOICES as choice}
-								<Button
-									style="background-color: {selected === choice ? 'var(--G5)' : 'var(--G6)'}"
-									variant="outlined"
-									on:click={() => (selected = choice)}>{choice}</Button
-								>
-							{/each}
-						{/if}
+						{#each CHOICES as choice}
+							<Button
+								style="background-color: {selected === choice ? 'var(--G5)' : 'var(--G6)'}"
+								variant="outlined"
+								on:click={() => (selected = choice)}>{choice}</Button
+							>
+						{/each}
 					</Group>
 				{:else}
 					<div class="flex items-center" style="margin-right: 10px">

--- a/frontend/src/lib/components/metadata/SliceHeader.svelte
+++ b/frontend/src/lib/components/metadata/SliceHeader.svelte
@@ -45,7 +45,7 @@
 			</Icon>
 		</div>
 	</div>
-	{#if $project && $project.editor}
+	{#if $project.editor}
 		<div class="flex items-center justify-between">
 			<div
 				use:tooltip={{

--- a/frontend/src/lib/components/metadata/Tags.svelte
+++ b/frontend/src/lib/components/metadata/Tags.svelte
@@ -12,7 +12,7 @@
 	let showNewTag = false;
 
 	function saveChanges() {
-		if ($editTag === undefined || $project === undefined) return;
+		if ($editTag === undefined) return;
 		ZenoService.updateTag($project.uuid, {
 			...$editTag,
 			dataIds: Array.from(new Set([...$editTag.dataIds, ...$editedIds]))
@@ -55,7 +55,7 @@
 			</Icon>
 		</div>
 	</div>
-	{#if $project && $project.editor && !$page.url.href.includes('compare')}
+	{#if $project.editor && !$page.url.href.includes('compare')}
 		<div class="flex items-center justify-between">
 			<div>
 				<div

--- a/frontend/src/lib/components/metadata/cells/FolderCell.svelte
+++ b/frontend/src/lib/components/metadata/cells/FolderCell.svelte
@@ -28,7 +28,7 @@
 			const data = ev.dataTransfer.getData('text/plain').split(',');
 			data.forEach((element) => {
 				const slice = $slices.find((slice) => slice.id === parseInt(element));
-				if (slice && $project) {
+				if (slice) {
 					ZenoService.updateSlice($project.uuid, {
 						...slice,
 						folderId: folder.id

--- a/frontend/src/lib/components/metadata/cells/SliceCell.svelte
+++ b/frontend/src/lib/components/metadata/cells/SliceCell.svelte
@@ -50,11 +50,11 @@
 	function dragEnd(e: DragEvent) {
 		if (e.dataTransfer !== null) {
 			// If dragged out of a folder, remove from the folder it was in.
-			if (e.dataTransfer.dropEffect === 'none' && $project) {
+			if (e.dataTransfer.dropEffect === 'none') {
 				const data = transferData.split(',');
 				data.forEach((element) => {
 					const slice = $slices.find((slice) => slice.id === parseInt(element));
-					if (slice && $project) {
+					if (slice) {
 						ZenoService.updateSlice($project.uuid, { ...slice, folderId: undefined }).then(() =>
 							slices.update((s) => {
 								invalidate('app:state');

--- a/frontend/src/lib/components/metadata/cells/SliceFinderCell.svelte
+++ b/frontend/src/lib/components/metadata/cells/SliceFinderCell.svelte
@@ -27,13 +27,11 @@
 	/** Save a generated slice to the slice drawer **/
 	function addSlice() {
 		slice.sliceName = newSliceName;
-		if ($project !== undefined) {
-			ZenoService.addSlice($project.uuid, slice).then((res) => {
-				slices.update((s) => [...s, { ...slice, id: res }]);
-				showSliceName = false;
-				created = true;
-			});
-		}
+		ZenoService.addSlice($project.uuid, slice).then((res) => {
+			slices.update((s) => [...s, { ...slice, id: res }]);
+			showSliceName = false;
+			created = true;
+		});
 	}
 
 	/** Remove a generated slice from the slice drawer **/

--- a/frontend/src/lib/components/metadata/cells/metadata-cells/ContinuousMetadataCell.svelte
+++ b/frontend/src/lib/components/metadata/cells/metadata-cells/ContinuousMetadataCell.svelte
@@ -66,7 +66,7 @@
 <div id="histogram" on:mouseup={setSelection}>
 	<VegaLite
 		bind:view
-		spec={continuousVegaSpec($metricRange, $project?.calculateHistogramMetrics ?? false)}
+		spec={continuousVegaSpec($metricRange, $project.calculateHistogramMetrics ?? false)}
 		data={{ table: histogram.map((h) => Object.assign({}, h)) }}
 		options={{
 			tooltip: true,

--- a/frontend/src/lib/components/metadata/cells/metadata-cells/NominalMetadataCell.svelte
+++ b/frontend/src/lib/components/metadata/cells/metadata-cells/NominalMetadataCell.svelte
@@ -63,7 +63,7 @@
 <div on:click={setSelection} on:keydown={() => ({})}>
 	<VegaLite
 		bind:view
-		spec={nominalVegaSpec($metricRange, $project?.calculateHistogramMetrics ?? false)}
+		spec={nominalVegaSpec($metricRange, $project.calculateHistogramMetrics ?? false)}
 		data={{ table: histogram.map((h) => Object.assign({}, h)) }}
 		options={{
 			tooltip: true,

--- a/frontend/src/lib/components/metadata/cells/metadata-cells/TextMetadataCell.svelte
+++ b/frontend/src/lib/components/metadata/cells/metadata-cells/TextMetadataCell.svelte
@@ -71,17 +71,13 @@
 		}
 
 		try {
-			if ($project) {
-				results = await ZenoService.filterStringMetadata($project.uuid, {
-					column: col,
-					filterString: input,
-					operation: operation
-				});
-				return results;
-			}
+			results = await ZenoService.filterStringMetadata($project.uuid, {
+				column: col,
+				filterString: input,
+				operation: operation
+			});
 		} catch (e) {
 			results = [];
-			return results;
 		}
 		return results;
 	}

--- a/frontend/src/lib/components/popups/FolderPopup.svelte
+++ b/frontend/src/lib/components/popups/FolderPopup.svelte
@@ -21,7 +21,7 @@
 	}
 
 	function editFolder() {
-		if (folderToEdit && $project) {
+		if (folderToEdit) {
 			ZenoService.updateFolder($project.uuid, {
 				...folderToEdit,
 				name: folderName
@@ -40,17 +40,15 @@
 
 	/** Create a folder using the folderName variable **/
 	function createFolder() {
-		if ($project) {
-			ZenoService.addFolder($project.uuid, folderName).then((res) => {
-				folders.update((f) => [
-					...f,
-					{
-						id: res,
-						name: folderName
-					}
-				]);
-			});
-		}
+		ZenoService.addFolder($project.uuid, folderName).then((res) => {
+			folders.update((f) => [
+				...f,
+				{
+					id: res,
+					name: folderName
+				}
+			]);
+		});
 		dispatch('close');
 	}
 

--- a/frontend/src/lib/components/popups/ProjectPopup.svelte
+++ b/frontend/src/lib/components/popups/ProjectPopup.svelte
@@ -22,8 +22,8 @@
 	let selectedUser: User | undefined;
 	let selectedOrg: Organization | undefined;
 
-	let userRequest = $project ? ZenoService.getProjectUsers($project.uuid) : undefined;
-	let organizationRequest = $project ? ZenoService.getProjectOrgs($project.uuid) : undefined;
+	let userRequest = ZenoService.getProjectUsers($project.uuid);
+	let organizationRequest = ZenoService.getProjectOrgs($project.uuid);
 
 	$: invalidName = config.name.length === 0;
 	$: if (input) {
@@ -47,28 +47,18 @@
 	}
 
 	function addUser(e: CustomEvent) {
-		$project &&
-			ZenoService.addProjectUser($project.uuid, {
-				...e.detail,
-				admin: false
-			}).then(() => {
-				if ($project) {
-					userRequest = ZenoService.getProjectUsers($project.uuid);
-				}
-			});
+		ZenoService.addProjectUser($project.uuid, {
+			...e.detail,
+			admin: false
+		}).then(() => (userRequest = ZenoService.getProjectUsers($project.uuid)));
 		selectedUser = undefined;
 	}
 
 	function addOrganization(e: CustomEvent) {
-		$project &&
-			ZenoService.addProjectOrg($project.uuid, {
-				...e.detail,
-				admin: false
-			}).then(() => {
-				if ($project) {
-					organizationRequest = ZenoService.getProjectOrgs($project.uuid);
-				}
-			});
+		ZenoService.addProjectOrg($project.uuid, {
+			...e.detail,
+			admin: false
+		}).then(() => (organizationRequest = ZenoService.getProjectOrgs($project.uuid)));
 		selectedOrg = undefined;
 	}
 </script>
@@ -135,15 +125,10 @@
 											<Checkbox
 												checked={member.admin}
 												on:click={() =>
-													$project &&
 													ZenoService.updateProjectUser($project.uuid, {
 														...member,
 														admin: !member.admin
-													}).then(() => {
-														if ($project) {
-															userRequest = ZenoService.getProjectUsers($project.uuid);
-														}
-													})}
+													}).then(() => (userRequest = ZenoService.getProjectUsers($project.uuid)))}
 												disabled={member.id === user.id}
 											/>
 										</td>
@@ -151,12 +136,9 @@
 											{#if member.id !== user.id}
 												<IconButton
 													on:click={() =>
-														$project &&
-														ZenoService.deleteProjectUser($project.uuid, member).then(() => {
-															if ($project) {
-																userRequest = ZenoService.getProjectUsers($project.uuid);
-															}
-														})}
+														ZenoService.deleteProjectUser($project.uuid, member).then(
+															() => (userRequest = ZenoService.getProjectUsers($project.uuid))
+														)}
 												>
 													<Icon tag="svg" viewBox="0 0 24 24">
 														<path fill="black" d={mdiClose} />
@@ -216,26 +198,20 @@
 											<Checkbox
 												checked={org.admin}
 												on:click={() =>
-													$project &&
 													ZenoService.updateProjectOrg($project.uuid, {
 														...org,
 														admin: !org.admin
-													}).then(() => {
-														if ($project) {
-															organizationRequest = ZenoService.getProjectOrgs($project.uuid);
-														}
-													})}
+													}).then(
+														() => (organizationRequest = ZenoService.getProjectOrgs($project.uuid))
+													)}
 											/>
 										</td>
 										<td style="text-align: end;">
 											<IconButton
 												on:click={() =>
-													$project &&
-													ZenoService.deleteProjectOrg($project.uuid, org).then(() => {
-														if ($project) {
-															organizationRequest = ZenoService.getProjectOrgs($project.uuid);
-														}
-													})}
+													ZenoService.deleteProjectOrg($project.uuid, org).then(
+														() => (organizationRequest = ZenoService.getProjectOrgs($project.uuid))
+													)}
 											>
 												<Icon tag="svg" viewBox="0 0 24 24">
 													<path fill="black" d={mdiClose} />

--- a/frontend/src/lib/components/popups/SliceFinderPopup.svelte
+++ b/frontend/src/lib/components/popups/SliceFinderPopup.svelte
@@ -101,7 +101,7 @@
 			return;
 		}
 		sliceFinderMessage = 'Generating Slices...';
-		if ($project !== undefined && metricColumn !== undefined) {
+		if (metricColumn !== undefined) {
 			const secureTagIds = $tagIds === undefined ? [] : $tagIds;
 			const secureSelectionIds = $selectionIds === undefined ? [] : $selectionIds;
 			const dataIds = [...new Set([...secureTagIds, ...secureSelectionIds])];

--- a/frontend/src/lib/components/popups/SlicePopup.svelte
+++ b/frontend/src/lib/components/popups/SlicePopup.svelte
@@ -107,7 +107,7 @@
 			sliceName = 'Slice ' + $slices.length;
 		}
 
-		if (sliceToEdit && $project) {
+		if (sliceToEdit) {
 			ZenoService.updateSlice($project.uuid, {
 				id: sliceToEdit.id,
 				sliceName,
@@ -126,7 +126,7 @@
 				});
 			});
 		} else {
-			ZenoService.addSlice($project ? $project.uuid : '', {
+			ZenoService.addSlice($project.uuid, {
 				id: 0,
 				sliceName,
 				filterPredicates: predicateGroup,

--- a/frontend/src/lib/components/popups/TagPopup.svelte
+++ b/frontend/src/lib/components/popups/TagPopup.svelte
@@ -26,23 +26,21 @@
 			tagName = 'Tag ' + $tags.length;
 		}
 
-		if ($project !== undefined) {
-			ZenoService.addTag($project.uuid, {
-				id: 0,
-				tagName,
-				dataIds: []
-			}).then((res) => {
-				tags.update((t) => [
-					...t,
-					{
-						id: res,
-						tagName,
-						dataIds: []
-					}
-				]);
-				dispatch('close');
-			});
-		}
+		ZenoService.addTag($project.uuid, {
+			id: 0,
+			tagName,
+			dataIds: []
+		}).then((res) => {
+			tags.update((t) => [
+				...t,
+				{
+					id: res,
+					tagName,
+					dataIds: []
+				}
+			]);
+			dispatch('close');
+		});
 	}
 
 	function submit(e: KeyboardEvent) {

--- a/frontend/src/lib/stores.ts
+++ b/frontend/src/lib/stores.ts
@@ -13,7 +13,7 @@ import {
 import { interpolate } from 'd3-interpolate';
 import { derived, get, writable, type Readable, type Writable } from 'svelte/store';
 
-export const project: Writable<Project | undefined> = writable(undefined);
+export const project: Writable<Project> = writable();
 export const authToken: Writable<string | undefined> = writable(undefined);
 export const slices: Writable<Slice[]> = writable([]);
 export const columns: Writable<ZenoColumn[]> = writable([]);

--- a/frontend/src/routes/(app)/project/[owner]/[project]/chart/+page.svelte
+++ b/frontend/src/routes/(app)/project/[owner]/[project]/chart/+page.svelte
@@ -16,19 +16,15 @@
 	<div class="flex flex-col bg-white p-6 m-4 shadow-md rounded">
 		<div class="flex align-center mb-7">
 			<h3 class="text-xl mr-5">Charts</h3>
-			{#if $project && $project.editor}
+			{#if $project.editor}
 				<button
 					class="border-solid rounded-sm border-grey-light border shadow-sm flex flex-col hover:shadow-md p-1 pr-3 pl-1"
 					on:click={() => {
 						ZenoService.addChart(
-							$project ? $project.uuid : '',
-							chartDefaults('New Chart', 0, $project?.uuid ?? '', ChartType.BAR)
+							$project.uuid,
+							chartDefaults('New Chart', 0, $project.uuid, ChartType.BAR)
 						).then((res) => {
-							goto(
-								`/project/${$project ? $project.ownerName : ''}/${
-									$project ? $project.name : ''
-								}/chart/${res}?edit=true`
-							);
+							goto(`/project/${$project.ownerName}/${$project.name}/chart/${res}?edit=true`);
 						});
 					}}
 				>

--- a/frontend/src/routes/(app)/project/[owner]/[project]/chart/[chartIndex=integer]/+page.svelte
+++ b/frontend/src/routes/(app)/project/[owner]/[project]/chart/[chartIndex=integer]/+page.svelte
@@ -36,14 +36,14 @@
 	}
 
 	function updateChart(chart: Chart) {
-		if ($project && $project.editor && browser) {
+		if ($project.editor && browser) {
 			ZenoService.updateChart($project.uuid, chart);
 		}
 	}
 </script>
 
 <div class={`w-full flex overflow-hidden ${isChartEdit ? 'flex-row' : 'flex-col'}`}>
-	{#if isChartEdit && $project?.editor}
+	{#if isChartEdit && $project.editor}
 		<div
 			class="border-r border-r-grey-lighter h-full pb-20 px-5 overflow-y-auto shrink-0 bg-yellowish-light w-[380px]"
 		>


### PR DESCRIPTION
# Description
Must always have a project object when looking at a project (set by layout), so don't have to check everywhere.