### PR TITLE
fix: call /login on login so that user is created if not existing

### DIFF
--- a/frontend/src/routes/(user)/login/+page.server.ts
+++ b/frontend/src/routes/(user)/login/+page.server.ts
@@ -1,7 +1,8 @@
 import { dev } from '$app/environment';
 import { env as private_env } from '$env/dynamic/private';
 import { extractUserFromSession, getSession } from '$lib/auth/cognito';
-import { OpenAPI } from '$lib/zenoapi';
+import { getEndpoint } from '$lib/util/util';
+import { OpenAPI, ZenoService } from '$lib/zenoapi';
 import { fail, redirect } from '@sveltejs/kit';
 import type { Actions } from './$types';
 
@@ -52,6 +53,9 @@ export const actions: Actions = {
 				showReset: err.name === 'NotAuthorizedException'
 			});
 		}
+
+		OpenAPI.BASE = getEndpoint() + '/api';
+		await ZenoService.login(username);
 		throw redirect(303, url.searchParams.get('redirectTo') ?? '/');
 	}
 };


### PR DESCRIPTION
# Description

Fixes the issue that the user was not in the DB directly after signup when fetching user's projects and reports.